### PR TITLE
fix InexactError on conversion for HiGHS solver

### DIFF
--- a/src/zarate.jl
+++ b/src/zarate.jl
@@ -198,7 +198,7 @@ end
 function order_layers!(layer2nodes, is_before)
     # Cunning trick: we need to go from the `before` matrix to an actual order list
     # we can do this by sorting when having `lessthan` read from the `before` matrix
-    is_before_func(n1, n2) = Bool(value(is_before[n1][n2]))
+    is_before_func(n1, n2) = round(Bool, value(is_before[n1][n2]))::Bool
     for layer in layer2nodes
         sort!(layer; lt=is_before_func)
     end


### PR DESCRIPTION
I was trying out the HiGHS solver as an alternative to Cbc via
```jl
solver_positions(..., Zarate(ordering_solver=optimizer_with_attributes(HiGHS.Optimizer)))
```

For certain problems, this threw the following error:
```jl
ERROR: InexactError: Bool(-2.220446049250313e-16)
Stacktrace:
  [1] Bool(x::Float64)
    @ Base .\float.jl:158
  [2] (::LayeredLayouts.var"#is_before_func#44"{Vector{Any}})(n1::Int64, n2::Int64)
    @ LayeredLayouts C:\Users\tchr\.julia\dev\LayeredLayouts\src\zarate.jl:202
  [3] #1
    @ .\ordering.jl:133 [inlined]
  [4] lt
    @ .\ordering.jl:120 [inlined]
  [5] sort!(v::Vector{Int64}, lo::Int64, hi::Int64, #unused#::Base.Sort.InsertionSortAlg, o::Base.Order.Lt{Base.Order.var"#1#3"{LayeredLayouts.var"#is_before_func#44"{Vector{Any}}, typeof(identity)}})
    @ Base.Sort .\sort.jl:504
  [6] sort!(v::Vector{Int64}, lo::Int64, hi::Int64, a::Base.Sort.QuickSortAlg, o::Base.Order.Lt{Base.Order.var"#1#3"{LayeredLayouts.var"#is_before_func#44"{Vector{Any}}, typeof(identity)}})
    @ Base.Sort .\sort.jl:570
  [7] sort!
    @ .\sort.jl:660 [inlined]
  [8] #sort!#8
    @ .\sort.jl:721 [inlined]
  [9] order_layers!
    @ C:\Users\tchr\.julia\dev\LayeredLayouts\src\zarate.jl:204 [inlined]
 [10] solve_positions(layout::Zarate, original_graph::Graphs.SimpleGraphs.SimpleDiGraph{Int64}; force_layer::Vector{Pair{Int64, Int64}}, force_order::Vector{Pair{Int64, Int64}})
    @ LayeredLayouts C:\Users\tchr\.julia\dev\LayeredLayouts\src\zarate.jl:93
[...]
```

I imagine that the assumption that `value(isbefore[n1][n2])` is an integer is not necessarily true for all solvers. This is a suggested fix for those cases.