### PR TITLE
Use rounding to determine sorting order

### DIFF
--- a/src/zarate.jl
+++ b/src/zarate.jl
@@ -198,7 +198,7 @@ end
 function order_layers!(layer2nodes, is_before)
     # Cunning trick: we need to go from the `before` matrix to an actual order list
     # we can do this by sorting when having `lessthan` read from the `before` matrix
-    is_before_func(n1, n2) = Bool(value(is_before[n1][n2]))
+    is_before_func(n1, n2) = round(Bool, value(is_before[n1][n2]))
     for layer in layer2nodes
         sort!(layer; lt=is_before_func)
     end


### PR DESCRIPTION
Should close #33 

The problem is to make solving faster we take a linear relaxation of what should be a binary constraint allowing it to be and number between 0 and 1. But the math (according to Zarate's paper) is such that it will always actually be zero or one. But I am guessing numerical error crept in.
Which resulted in a call to `Bool(0.99999)`  which is an error. but `round(Bool, 0.99999)` should have perfectly fine behavour.

This does possibly indicate a pathological case is possible where enough numerical error creep in that things could end up being assigned inconsistencely, so that `a` is before `b`, and `b` is before `a`, which might cause it to loop, but seems super dooper unlikely given people have been using this package for years, esp via Sankey.jl and this is the first time it moved from `1.0` or `0.0` that i am hearing about.